### PR TITLE
Register system information toolbar event listener

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,12 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  T3kit\\themeT3kit\\EventListener\\SystemInformationToolbarListener:
+    tags:
+      - name: event.listener
+        identifier: 'theme-t3kit/system-information-toolbar'
+        event: TYPO3\\CMS\\Backend\\Event\\SystemInformationToolbarCollectorEvent
+        method: 'addThemeModeInformation'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -26,19 +26,6 @@ $GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['t3kit_default']
 
 $GLOBALS['TYPO3_CONF_VARS']['BE']['interfaces'] = 'frontend,backend';
 
-// register to signal slot from SystemInformationToolbarItem to include
-// Themes Development Mode constant setting per "siteroot" to system information
-$signalSlotDispatcher = TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-    \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
-);
-$signalSlotDispatcher->connect(
-    \TYPO3\CMS\Backend\Backend\ToolbarItems\SystemInformationToolbarItem::class,
-    'getSystemInformation',
-    \T3kit\themeT3kit\Slot\GetSystemInformationSlot::class,
-    'getSystemInformation'
-);
-
-
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
     '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/PageTS/tsconfig.txt">'
 );


### PR DESCRIPTION
## Summary
- replace the legacy signal-slot registration for system information toolbar information with a PSR-14 listener
- expose the listener via Services.yaml so the theme mode information continues to be provided through the event API

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68ce5f39ead08329838b63f58231286c