### PR TITLE
Update TYPO3 guards for v13

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') || die();
 
 call_user_func(function () {
     $GLOBALS['TCA']['pages']['columns']['tx_themes_icon']['config'] = array(

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') || die();
 
 call_user_func(function() {
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') || die();
 
 call_user_func(function() {
     if (!isset($GLOBALS['TCA']['tt_content']['palettes']['frames'])) {

--- a/Configuration/TCA/Overrides/tx_news_slug_fields.php
+++ b/Configuration/TCA/Overrides/tx_news_slug_fields.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die();
 
 call_user_func(function () {
     $tableToField = [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,7 +1,5 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
+defined('TYPO3') || die();
 
 if (!TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('frontend_editing')) {
     // Add an empty placeholder viewhelper if the EXT:frontend_editing is not active
@@ -22,10 +20,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['t3kit'][] = 'T3kit\\t
 
 $GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['t3kit_default']
     = 'EXT:theme_t3kit/Resources/Private/Extensions/RTE/Default.yaml';
-
-
-$GLOBALS['TYPO3_CONF_VARS']['BE']['interfaces'] = 'frontend,backend';
-
 // register to signal slot from SystemInformationToolbarItem to include
 // Themes Development Mode constant setting per "siteroot" to system information
 $signalSlotDispatcher = TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,7 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') || die();
+
+use TYPO3\CMS\Core\Core\Environment;
 
 $boot = function ($_EXTKEY) {
 
@@ -64,7 +66,7 @@ $boot = function ($_EXTKEY) {
         ['source' => 'EXT:solr/Resources/Public/Images/Icons/ContentElement.svg']
     );
 
-    if (TYPO3_MODE === 'BE') {
+    if (Environment::isBackend()) {
         // Add context sensitive help (csh) for the haiku table
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr(
             'tt_content',


### PR DESCRIPTION
## Summary
- replace legacy TYPO3_MODE access guards with the TYPO3 v13 `defined('TYPO3') || die();` idiom across configuration files
- remove deprecated backend interfaces configuration from `ext_localconf.php`
- switch backend detection in `ext_tables.php` to `Environment::isBackend()` for modern runtime checks

## Testing
- php -l ext_localconf.php
- php -l ext_tables.php
- php -l Configuration/TCA/Overrides/tx_news_slug_fields.php
- php -l Configuration/TCA/Overrides/tt_content.php
- php -l Configuration/TCA/Overrides/pages.php
- php -l Configuration/TCA/Overrides/sys_file_reference.php

------
https://chatgpt.com/codex/tasks/task_e_68ce5f394b1083299cf80388cf9dcda6